### PR TITLE
Feat/minco/weather

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,9 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+	//날씨 API 추가
+	implementation 'org.json:json:20231013'
+
 }
 
 

--- a/src/main/java/DC_square/spring/config/SwaggerConfig.java
+++ b/src/main/java/DC_square/spring/config/SwaggerConfig.java
@@ -1,10 +1,14 @@
 package DC_square.spring.config;
 
+import DC_square.spring.domain.enums.DogCat;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import jakarta.persistence.Column;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import org.springframework.context.annotation.Bean;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/DC_square/spring/constant/ImageConstants.java
+++ b/src/main/java/DC_square/spring/constant/ImageConstants.java
@@ -1,0 +1,7 @@
+package DC_square.spring.constant;
+
+
+public class ImageConstants {
+    public static final String DEFAULT_PROFILE_IMAGE = "https://dogcatsquare.s3.ap-northeast-2.amazonaws.com/profile/bd681056-ddb5-4c3f-b455-f16756f65867";
+    public static final String DEFAULT_PET_IMAGE = "https://dogcatsquare.s3.ap-northeast-2.amazonaws.com/profile/bd681056-ddb5-4c3f-b455-f16756f65867";
+}

--- a/src/main/java/DC_square/spring/constant/WeatherConstants.java
+++ b/src/main/java/DC_square/spring/constant/WeatherConstants.java
@@ -12,7 +12,7 @@ public class WeatherConstants {
     public static final String RAIN_TYPE = "PTY"; // 강수 형태
     public static final String SKY = "SKY";  // 하늘 상태
     public static final String WIND_SPEED = "WSD";  // 풍속
-
+    public static final String   RAIN_PROBABILITY="POP"; //강수 확률
 
     // S3 이미지 url
     public static final String DOG_SUN_IMAGE = "https://dogcatsquare.s3.ap-northeast-2.amazonaws.com/weather/dog_sun";

--- a/src/main/java/DC_square/spring/constant/WeatherConstants.java
+++ b/src/main/java/DC_square/spring/constant/WeatherConstants.java
@@ -15,19 +15,19 @@ public class WeatherConstants {
     public static final String   RAIN_PROBABILITY="POP"; //강수 확률
 
     // S3 이미지 url
-    public static final String DOG_SUN_IMAGE = "https://dogcatsquare.s3.ap-northeast-2.amazonaws.com/weather/dog_sun";
-    public static final String DOG_RAIN_IMAGE = "https://dogcatsquare.s3.ap-northeast-2.amazonaws.com/weather/dog_rain";
-    public static final String DOG_SNOW_IMAGE = "https://dogcatsquare.s3.ap-northeast-2.amazonaws.com/weather/dog_snow";
-    public static final String DOG_WIND_IMAGE = "https://dogcatsquare.s3.ap-northeast-2.amazonaws.com/weather/dog_wind";
-    public static final String DOG_BOX_IMAGE = "https://dogcatsquare.s3.ap-northeast-2.amazonaws.com/weather/dog_box";
-    public static final String DOG_HOSPITAL_IMAGE = "https://dogcatsquare.s3.ap-northeast-2.amazonaws.com/weather/dog_hospital";
+    public static final String DOG_SUN_IMAGE = "https://dogcatsquare.s3.ap-northeast-2.amazonaws.com/weather/sun_dog.png";
+    public static final String DOG_RAIN_IMAGE = "https://dogcatsquare.s3.ap-northeast-2.amazonaws.com/weather/rain_dog.png";
+    public static final String DOG_SNOW_IMAGE = "https://dogcatsquare.s3.ap-northeast-2.amazonaws.com/weather/snow_dog.png";
+    public static final String DOG_WIND_IMAGE = "https://dogcatsquare.s3.ap-northeast-2.amazonaws.com/weather/wind_dog.png";
+    public static final String DOG_BOX_IMAGE = "https://dogcatsquare.s3.ap-northeast-2.amazonaws.com/weather/box_dog.png";
+    public static final String DOG_HOSPITAL_IMAGE = "https://dogcatsquare.s3.ap-northeast-2.amazonaws.com/weather/hospital_dog.png";
 
-    public static final String CAT_SUN_IMAGE = "https://dogcatsquare.s3.ap-northeast-2.amazonaws.com/weather/cat_sun";
-    public static final String CAT_RAIN_IMAGE = "https://dogcatsquare.s3.ap-northeast-2.amazonaws.com/weather/cat_rain";
-    public static final String CAT_SNOW_IMAGE = "https://dogcatsquare.s3.ap-northeast-2.amazonaws.com/weather/cat_snow";
-    public static final String CAT_WIND_IMAGE = "https://dogcatsquare.s3.ap-northeast-2.amazonaws.com/weather/cat_wind";
-    public static final String CAT_BOX_IMAGE = "https://dogcatsquare.s3.ap-northeast-2.amazonaws.com/weather/cat_box";
-    public static final String CAT_HOSPITAL_IMAGE = "https://dogcatsquare.s3.ap-northeast-2.amazonaws.com/weather/cat_hospital";
+    public static final String CAT_SUN_IMAGE = "https://dogcatsquare.s3.ap-northeast-2.amazonaws.com/weather/sun_cat.png";
+    public static final String CAT_RAIN_IMAGE = "https://dogcatsquare.s3.ap-northeast-2.amazonaws.com/weather/rain_cat.png";
+    public static final String CAT_SNOW_IMAGE = "https://dogcatsquare.s3.ap-northeast-2.amazonaws.com/weather/snow_cat.png";
+    public static final String CAT_WIND_IMAGE = "https://dogcatsquare.s3.ap-northeast-2.amazonaws.com/weather/wind_cat.png";
+    public static final String CAT_BOX_IMAGE = "https://dogcatsquare.s3.ap-northeast-2.amazonaws.com/weather/box_cat.png";
+    public static final String CAT_HOSPITAL_IMAGE = "https://dogcatsquare.s3.ap-northeast-2.amazonaws.com/weather/hospital_cat.png";
 
     // 날씨 파라미터 임계값
     public static final double STRONG_WIND_SPEED = 7.0;  // 강풍 기준 (m/s)

--- a/src/main/java/DC_square/spring/constant/WeatherConstants.java
+++ b/src/main/java/DC_square/spring/constant/WeatherConstants.java
@@ -1,0 +1,34 @@
+package DC_square.spring.constant;
+
+public class WeatherConstants {
+    //url
+    public static final String WEATHER_API_BASE_URL = "https://apihub.kma.go.kr/api/typ02/openApi/VilageFcstInfoService_2.0";
+    public static final String WEATHER_FORECAST_URL = WEATHER_API_BASE_URL + "/getVilageFcst";
+
+    // 날씨 카테고리
+    public static final String TEMPERATURE = "TMP";  // 1시간 기온
+    public static final String MAX_TEMP = "TMX"; // 최고 기온
+    public static final String MIN_TEMP = "TMN";  // 최저 기온
+    public static final String RAIN_TYPE = "PTY"; // 강수 형태
+    public static final String SKY = "SKY";  // 하늘 상태
+    public static final String WIND_SPEED = "WSD";  // 풍속
+
+
+    // S3 이미지 url
+    public static final String DOG_SUN_IMAGE = "https://dogcatsquare.s3.ap-northeast-2.amazonaws.com/weather/dog_sun";
+    public static final String DOG_RAIN_IMAGE = "https://dogcatsquare.s3.ap-northeast-2.amazonaws.com/weather/dog_rain";
+    public static final String DOG_SNOW_IMAGE = "https://dogcatsquare.s3.ap-northeast-2.amazonaws.com/weather/dog_snow";
+    public static final String DOG_WIND_IMAGE = "https://dogcatsquare.s3.ap-northeast-2.amazonaws.com/weather/dog_wind";
+    public static final String DOG_BOX_IMAGE = "https://dogcatsquare.s3.ap-northeast-2.amazonaws.com/weather/dog_box";
+    public static final String DOG_HOSPITAL_IMAGE = "https://dogcatsquare.s3.ap-northeast-2.amazonaws.com/weather/dog_hospital";
+
+    public static final String CAT_SUN_IMAGE = "https://dogcatsquare.s3.ap-northeast-2.amazonaws.com/weather/cat_sun";
+    public static final String CAT_RAIN_IMAGE = "https://dogcatsquare.s3.ap-northeast-2.amazonaws.com/weather/cat_rain";
+    public static final String CAT_SNOW_IMAGE = "https://dogcatsquare.s3.ap-northeast-2.amazonaws.com/weather/cat_snow";
+    public static final String CAT_WIND_IMAGE = "https://dogcatsquare.s3.ap-northeast-2.amazonaws.com/weather/cat_wind";
+    public static final String CAT_BOX_IMAGE = "https://dogcatsquare.s3.ap-northeast-2.amazonaws.com/weather/cat_box";
+    public static final String CAT_HOSPITAL_IMAGE = "https://dogcatsquare.s3.ap-northeast-2.amazonaws.com/weather/cat_hospital";
+
+    // 날씨 파라미터 임계값
+    public static final double STRONG_WIND_SPEED = 7.0;  // 강풍 기준 (m/s)
+}

--- a/src/main/java/DC_square/spring/domain/entity/Dday.java
+++ b/src/main/java/DC_square/spring/domain/entity/Dday.java
@@ -4,6 +4,7 @@ import DC_square.spring.domain.enums.DdayType;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 
 @Entity
 @Getter
@@ -46,5 +47,9 @@ public class Dday {
             case CUSTOM: this.imageUrl = "https://dogcatsquare.s3.ap-northeast-2.amazonaws.com/pet/3057edc6-9efa-4147-ba88-6276f057ffbb";
                 break;
         }
+    }
+
+    public long getDaysLeft() {
+        return ChronoUnit.DAYS.between(LocalDate.now(), this.day);
     }
 }

--- a/src/main/java/DC_square/spring/domain/entity/User.java
+++ b/src/main/java/DC_square/spring/domain/entity/User.java
@@ -1,6 +1,7 @@
 package DC_square.spring.domain.entity;
 
 
+import DC_square.spring.domain.entity.region.District;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -32,8 +33,11 @@ public class User {
     @Column(nullable = false, length = 11)
     private String phoneNumber;
 
-    @Column
-    private String regionId;
+//    @Column
+//    private String regionId;
+@ManyToOne(fetch = FetchType.LAZY)
+@JoinColumn(name = "district_id")
+private District district;
 
     @OneToMany(mappedBy = "user",cascade = CascadeType.ALL)
     private List<Pet> petList = new ArrayList<>();

--- a/src/main/java/DC_square/spring/domain/entity/region/City.java
+++ b/src/main/java/DC_square/spring/domain/entity/region/City.java
@@ -20,10 +20,10 @@ public class City {
     private String name; // 시/구 이름 (예: 강남구, 수원시)
 
     @Column(nullable = false)
-    private Integer gridX;  // 기상청 X좌표
+    private Integer grid_X;  // 기상청 X좌표
 
     @Column(nullable = false)
-    private Integer gridY;  // 기상청 Y좌표
+    private Integer grid_Y;  // 기상청 Y좌표
 
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/DC_square/spring/domain/entity/region/City.java
+++ b/src/main/java/DC_square/spring/domain/entity/region/City.java
@@ -19,6 +19,13 @@ public class City {
     @Column(nullable = false)
     private String name; // 시/구 이름 (예: 강남구, 수원시)
 
+    @Column(nullable = false)
+    private Integer gridX;  // 기상청 X좌표
+
+    @Column(nullable = false)
+    private Integer gridY;  // 기상청 Y좌표
+
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "province_id", nullable = false)
     private Province province;

--- a/src/main/java/DC_square/spring/domain/enums/WeatherStatus.java
+++ b/src/main/java/DC_square/spring/domain/enums/WeatherStatus.java
@@ -1,0 +1,40 @@
+package DC_square.spring.domain.enums;
+
+import DC_square.spring.constant.WeatherConstants;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum WeatherStatus {
+    SUNNY("맑음"),
+    CLOUDY("흐림"),
+    RAINY("비"),
+    SNOWY("눈"),
+    WINDY("강풍");
+
+    private final String description;
+
+    public static WeatherStatus fromWeatherData(String pty, String sky, double windSpeed) {
+        // 강수 형태 체크
+        if (pty != null) {
+            switch (pty) {
+                case "1":
+                case "2": return RAINY;  // 비 또는 비/눈
+                case "3": return SNOWY;  // 눈
+            }
+        }
+
+        // 강풍 체크
+        if (windSpeed >= WeatherConstants.STRONG_WIND_SPEED) {
+            return WINDY;
+        }
+
+        // 하늘 상태 체크
+        if ("1".equals(sky)) {
+            return SUNNY;
+        }
+
+        return CLOUDY;
+    }
+}

--- a/src/main/java/DC_square/spring/repository/region/CityRepository.java
+++ b/src/main/java/DC_square/spring/repository/region/CityRepository.java
@@ -1,0 +1,13 @@
+package DC_square.spring.repository.region;
+
+import DC_square.spring.domain.entity.region.City;
+import DC_square.spring.domain.entity.region.Province;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface CityRepository extends JpaRepository<City, Long> {
+    Optional<City> findByNameAndProvince(String name, Province province);
+}

--- a/src/main/java/DC_square/spring/repository/region/DistrictRepository.java
+++ b/src/main/java/DC_square/spring/repository/region/DistrictRepository.java
@@ -1,0 +1,13 @@
+package DC_square.spring.repository.region;
+
+import DC_square.spring.domain.entity.region.City;
+import DC_square.spring.domain.entity.region.District;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface DistrictRepository extends JpaRepository<District, Long> {
+    Optional<District> findByNameAndCity(String name, City city);
+}

--- a/src/main/java/DC_square/spring/repository/region/ProvinceRepository.java
+++ b/src/main/java/DC_square/spring/repository/region/ProvinceRepository.java
@@ -1,0 +1,12 @@
+package DC_square.spring.repository.region;
+
+import DC_square.spring.domain.entity.region.Province;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ProvinceRepository extends JpaRepository<Province, Long> {
+    Optional<Province> findByName(String name);
+}

--- a/src/main/java/DC_square/spring/service/RegionService.java
+++ b/src/main/java/DC_square/spring/service/RegionService.java
@@ -1,25 +1,56 @@
 package DC_square.spring.service;
 
 import DC_square.spring.domain.entity.Region;
+import DC_square.spring.domain.entity.region.City;
+import DC_square.spring.domain.entity.region.District;
+import DC_square.spring.domain.entity.region.Province;
+import DC_square.spring.repository.region.CityRepository;
+import DC_square.spring.repository.region.DistrictRepository;
+import DC_square.spring.repository.region.ProvinceRepository;
 import DC_square.spring.web.dto.request.RegionRequestDTO;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import DC_square.spring.repository.RegionRepository;
 
 @Service
-@Transactional
 @RequiredArgsConstructor
+@Transactional
+@Slf4j
 public class RegionService {
-    private final RegionRepository regionRepository;
+    private final ProvinceRepository provinceRepository;
+    private final CityRepository cityRepository;
+    private final DistrictRepository districtRepository;
 
-    public Long creatRegion(RegionRequestDTO request) {
-        Region region = Region.builder()
-                .doName(request.getDoName())
-                .si(request.getSi())
-                .gu(request.getGu())
-                .build();
+    public District findOrCreateDistrict(String provinceName, String cityName, String districtName) {
+        // 1. Province 찾기 - 정확한 이름으로 찾기
+        Province province = provinceRepository.findByName(provinceName)
+                .orElseGet(() -> {
+                    log.info("Creating new province: {}", provinceName);
+                    return provinceRepository.save(Province.builder()
+                            .name(provinceName)
+                            .build());
+                });
 
-        return regionRepository.save(region).getId();
+        // 2. City 찾기 - 정확한 이름으로 찾기
+        City city = cityRepository.findByNameAndProvince(cityName, province)
+                .orElseGet(() -> {
+                    log.info("Creating new city: {} in province: {}", cityName, provinceName);
+                    return cityRepository.save(City.builder()
+                            .name(cityName)
+                            .province(province)
+                            .build());
+                });
+
+        // 3. District 찾기 - 정확한 이름으로 찾기
+        return districtRepository.findByNameAndCity(districtName, city)
+                .orElseGet(() -> {
+                    log.info("Creating new district: {} in city: {}", districtName, cityName);
+                    return districtRepository.save(District.builder()
+                            .name(districtName)
+                            .city(city)
+                            .build());
+                });
     }
 }

--- a/src/main/java/DC_square/spring/service/RegionService.java
+++ b/src/main/java/DC_square/spring/service/RegionService.java
@@ -24,33 +24,20 @@ public class RegionService {
     private final DistrictRepository districtRepository;
 
     public District findOrCreateDistrict(String provinceName, String cityName, String districtName) {
-        // 1. Province 찾기 - 정확한 이름으로 찾기
+       // 저장되지 않은 지역정보 입력시 오류 !
+        // 1. Province 찾기
         Province province = provinceRepository.findByName(provinceName)
-                .orElseGet(() -> {
-                    log.info("Creating new province: {}", provinceName);
-                    return provinceRepository.save(Province.builder()
-                            .name(provinceName)
-                            .build());
-                });
+                .orElseThrow(() -> new RuntimeException(
+                        String.format("존재하지 않는 시/도입니다: %s", provinceName)));
 
-        // 2. City 찾기 - 정확한 이름으로 찾기
+        // 2. City 찾기
         City city = cityRepository.findByNameAndProvince(cityName, province)
-                .orElseGet(() -> {
-                    log.info("Creating new city: {} in province: {}", cityName, provinceName);
-                    return cityRepository.save(City.builder()
-                            .name(cityName)
-                            .province(province)
-                            .build());
-                });
+                .orElseThrow(() -> new RuntimeException(
+                        String.format("존재하지 않는 시/구입니다: %s", cityName)));
 
-        // 3. District 찾기 - 정확한 이름으로 찾기
+        // 3. District 찾기
         return districtRepository.findByNameAndCity(districtName, city)
-                .orElseGet(() -> {
-                    log.info("Creating new district: {} in city: {}", districtName, cityName);
-                    return districtRepository.save(District.builder()
-                            .name(districtName)
-                            .city(city)
-                            .build());
-                });
+                .orElseThrow(() -> new RuntimeException(
+                        String.format("존재하지 않는 동입니다: %s", districtName)));
     }
 }

--- a/src/main/java/DC_square/spring/service/UserService.java
+++ b/src/main/java/DC_square/spring/service/UserService.java
@@ -7,13 +7,18 @@ import DC_square.spring.config.S3.UuidRepository;
 import DC_square.spring.config.jwt.JwtTokenProvider;
 import DC_square.spring.domain.entity.Dday;
 import DC_square.spring.domain.entity.Pet;
-import DC_square.spring.domain.entity.Region;
+import DC_square.spring.domain.entity.region.City;
+import DC_square.spring.domain.entity.region.District;
+import DC_square.spring.domain.entity.region.Province;
 import DC_square.spring.domain.enums.DdayType;
 import DC_square.spring.repository.dday.DdayRepository;
 import DC_square.spring.domain.entity.User;
 import DC_square.spring.repository.RegionRepository;
 import DC_square.spring.repository.PetRepository;
 import DC_square.spring.repository.community.UserRepository;
+import DC_square.spring.repository.region.CityRepository;
+import DC_square.spring.repository.region.DistrictRepository;
+import DC_square.spring.repository.region.ProvinceRepository;
 import DC_square.spring.web.dto.request.LoginRequestDto;
 import DC_square.spring.web.dto.request.user.UserRegistrationRequestDto;  // DTO 변경
 import DC_square.spring.web.dto.request.user.PetRegistrationDto;
@@ -40,11 +45,16 @@ public class UserService {
     private final JwtTokenProvider jwtTokenProvider;
     private final PasswordEncoder passwordEncoder;
     private final UserRepository userRepository;
+    private final ProvinceRepository provinceRepository;
+    private final CityRepository cityRepository;
+    private final DistrictRepository districtRepository;
     private final RegionRepository regionRepository;
     private final PetRepository petRepository;
     private final DdayRepository ddayRepository;
     private final UuidRepository uuidRepository;
     private final AmazonS3Manager s3Manager;
+    private final RegionService regionService;
+
 
     @Transactional
     public UserResponseDto createUser(UserRegistrationRequestDto request, MultipartFile profileImage, MultipartFile petImage) {
@@ -58,19 +68,25 @@ public class UserService {
             throw new RuntimeException("이미 존재하는 닉네임입니다.");
         }
 
+//        // 지역 정보 조회 또는 생성
+//        Region region = regionRepository.findByDoNameAndSiAndGu(
+//                request.getDoName(),
+//                request.getSi(),
+//                request.getGu()
+//        ).orElseGet(() -> { //조회 결과 없을 때 새롭게 생성 !
+//            Region newRegion = Region.builder()
+//                    .doName(request.getDoName())
+//                    .si(request.getSi())
+//                    .gu(request.getGu())
+//                    .build();
+//            return regionRepository.save(newRegion);
+//        });
         // 지역 정보 조회 또는 생성
-        Region region = regionRepository.findByDoNameAndSiAndGu(
+        District district = regionService.findOrCreateDistrict(
                 request.getDoName(),
                 request.getSi(),
                 request.getGu()
-        ).orElseGet(() -> { //조회 결과 없을 때 새롭게 생성 !
-            Region newRegion = Region.builder()
-                    .doName(request.getDoName())
-                    .si(request.getSi())
-                    .gu(request.getGu())
-                    .build();
-            return regionRepository.save(newRegion);
-        });
+        );
 
         // 프로필 이미지 업로드
         String profileImageUrl = null;
@@ -87,7 +103,8 @@ public class UserService {
                 .password(passwordEncoder.encode(request.getPassword())) // 비밀번호 변화나
                 .nickname(request.getNickname())
                 .phoneNumber(request.getPhoneNumber())
-                .regionId(region.getId().toString())
+              // .regionId(region.getId().toString())
+                .district(district)  // district를 직접 참조
                 .adAgree(request.getAdAgree())
                 .profileImageUrl(profileImageUrl)
                 .build();
@@ -199,9 +216,15 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
 
-        // 사용자의 regionId로 Region 정보 조회
-        Region region = regionRepository.findById(Long.parseLong(user.getRegionId()))
-                .orElseThrow(() -> new RuntimeException("지역 정보를 찾을 수 없습니다."));
+//        // 사용자의 regionId로 Region 정보 조회
+//        Region region = regionRepository.findById(Long.parseLong(user.getRegionId()))
+//                .orElseThrow(() -> new RuntimeException("지역 정보를 찾을 수 없습니다."));
+
+        // district를 통해 지역 정보 조회 (이미 연관관계로 매핑되어 있음)
+        District district = user.getDistrict();
+        if (district == null) {
+            throw new RuntimeException("지역 정보를 찾을 수 없습니다.");
+        }
 
         // 첫 번째 반려동물의 품종 가져오기
         String firstPetBreed = petRepository.findAllByUser(user).stream()
@@ -209,7 +232,7 @@ public class UserService {
                 .map(Pet::getBreed)
                 .orElse(null);
 
-        return UserInqueryResponseDto.fromUser(user, region, firstPetBreed);
+        return UserInqueryResponseDto.fromUser(user, firstPetBreed);
     }
 
     // 반려동물 추가

--- a/src/main/java/DC_square/spring/service/UserService.java
+++ b/src/main/java/DC_square/spring/service/UserService.java
@@ -5,6 +5,7 @@ import DC_square.spring.config.S3.AmazonS3Manager;
 import DC_square.spring.config.S3.Uuid;
 import DC_square.spring.config.S3.UuidRepository;
 import DC_square.spring.config.jwt.JwtTokenProvider;
+import DC_square.spring.constant.ImageConstants;
 import DC_square.spring.domain.entity.Dday;
 import DC_square.spring.domain.entity.Pet;
 import DC_square.spring.domain.entity.region.City;
@@ -89,7 +90,7 @@ public class UserService {
         );
 
         // 프로필 이미지 업로드
-        String profileImageUrl = null;
+        String profileImageUrl = ImageConstants.DEFAULT_PROFILE_IMAGE;  // 기본 이미지 설정
         if (profileImage != null && !profileImage.isEmpty()) {
             String uuid = UUID.randomUUID().toString();
             Uuid savedUuid = uuidRepository.save(Uuid.builder().uuid(uuid).build());
@@ -100,7 +101,7 @@ public class UserService {
         // RequestDto -> Entity, DB에 저장
         User user = User.builder()
                 .email(request.getEmail())
-                .password(passwordEncoder.encode(request.getPassword())) // 비밀번호 변화나
+                .password(passwordEncoder.encode(request.getPassword())) // 비밀번호 변환
                 .nickname(request.getNickname())
                 .phoneNumber(request.getPhoneNumber())
               // .regionId(region.getId().toString())
@@ -113,7 +114,7 @@ public class UserService {
         User savedUser = userRepository.save(user);
 
         // 반려동물 저장
-        String petImageUrl = null;
+        String petImageUrl = ImageConstants.DEFAULT_PET_IMAGE;  // 기본 이미지 설정
         if (petImage != null && !petImage.isEmpty()) {
             String uuid = UUID.randomUUID().toString();
             Uuid savedUuid = uuidRepository.save(Uuid.builder().uuid(uuid).build());

--- a/src/main/java/DC_square/spring/service/WeatherService.java
+++ b/src/main/java/DC_square/spring/service/WeatherService.java
@@ -169,7 +169,12 @@ public class WeatherService {
             WeatherStatus status = WeatherStatus.fromWeatherData(pty, sky, Double.parseDouble(wsd));
 
             // 6. 가장 가까운 D-day 찾기 (날씨가 흐린 경우)
-            Dday nearestDday = status == WeatherStatus.CLOUDY ? findNearestDday(user) : null;
+            // 원래 코드
+           // Dday nearestDday = status == WeatherStatus.CLOUDY ? findNearestDday(user) : null;
+
+            // 맑음일 때 테스트
+            Dday nearestDday = status == WeatherStatus.SUNNY ? findNearestDday(user) : null;
+
 
             // 7. 응답 생성
             return WeatherResponseDto.from(
@@ -190,6 +195,7 @@ public class WeatherService {
 
     private Dday findNearestDday(User user) {
         List<Dday> ddays = ddayRepository.findAllByUserOrderByDayAsc(user);
+        log.info("User's Ddays: {}", ddays);
         LocalDate today = LocalDate.now();
 
         return ddays.stream()
@@ -201,6 +207,10 @@ public class WeatherService {
                             title.equals("병원 방문일");
                     // 오늘 이후의 날짜만 필터
                     boolean isFutureDate = !dday.getDay().isBefore(today);
+
+                    // 필터링 과정 로그
+                    log.info("Checking Dday - Title: {}, Date: {}, isValidTitle: {}, isFutureDate: {}",
+                            title, dday.getDay(), isValidTitle, isFutureDate);
 
                     return isValidTitle && isFutureDate;
                 })

--- a/src/main/java/DC_square/spring/service/WeatherService.java
+++ b/src/main/java/DC_square/spring/service/WeatherService.java
@@ -1,0 +1,210 @@
+package DC_square.spring.service;
+
+import DC_square.spring.constant.WeatherConstants;
+import DC_square.spring.domain.entity.Dday;
+import DC_square.spring.domain.entity.Pet;
+import DC_square.spring.domain.entity.User;
+import DC_square.spring.domain.enums.WeatherStatus;
+import DC_square.spring.repository.community.UserRepository;
+import DC_square.spring.repository.dday.DdayRepository;
+import DC_square.spring.repository.PetRepository;
+import DC_square.spring.web.dto.response.WeatherResponseDto;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Comparator;
+import java.util.List;
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WeatherService {
+    @Value("${weather.service-key}")
+    private String serviceKey;
+
+    private final RestTemplate restTemplate;
+    private final UserRepository userRepository;
+    private final PetRepository petRepository;
+    private final DdayRepository ddayRepository;
+
+    @PostConstruct
+    public void testWeatherApiConnection() {
+        try {
+            String testUrl = String.format(
+                    WeatherConstants.WEATHER_FORECAST_URL +
+                            "?pageNo=1" +  // pageNo를 가장 먼저 배치
+                            "&base_date=%s" +
+                            "&base_time=0500" +
+                            "&authKey=%s" +  //  authKey 위치 조정
+                            "&numOfRows=1" +
+                            "&nx=55" +
+                            "&ny=127" +
+                            "&dataType=JSON", //  dataType을 마지막에 배치
+                    LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd")),
+                    URLEncoder.encode(serviceKey, StandardCharsets.UTF_8) // ✅ 올바르게 인코딩
+            );
+
+            ResponseEntity<String> response = restTemplate.getForEntity(testUrl, String.class);
+            log.info("Weather API Test Response: {}", response.getStatusCode());
+        } catch (Exception e) {
+            log.error("Weather API Connection Test Failed", e);
+        }
+    }
+
+    public WeatherResponseDto getCurrentWeather(Long userId) {
+
+        try {
+            // 1. 사용자와 반려동물 정보 조회
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+
+            Pet pet = petRepository.findByUser(user);
+            if (pet == null) {
+                throw new RuntimeException("반려동물 정보를 찾을 수 없습니다.");
+            }
+
+            // 2. API 호출 정보 준비
+            LocalDateTime now = LocalDateTime.now();
+            String baseDate = now.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+
+        //  String baseTime = String.format("%02d00", (now.getHour() / 3) * 3);
+            String baseTime = String.format("%02d00", ((now.getHour() >= 23 ? 0 : now.getHour()) / 3) * 3);
+
+            // 3. API 호출
+            String url = String.format(
+                    WeatherConstants.WEATHER_FORECAST_URL +
+                            "?pageNo=%d" +
+                            "&base_date=%s" +
+                            "&base_time=%s" +
+                            "&authKey=%s" +
+                            "&numOfRows=%d" +
+                            "&nx=%d" +
+                            "&ny=%d" +
+                            "&dataType=JSON",
+                    1,  // pageNo
+                    baseDate,
+                   // baseTime,
+                    "0200",
+                    URLEncoder.encode(serviceKey, StandardCharsets.UTF_8), // authKey  인코딩
+                    260,  // numOfRows
+                    user.getDistrict().getCity().getGrid_X(),
+                    user.getDistrict().getCity().getGrid_Y()
+            );
+
+            log.info("Weather API Request URL: {}", url);
+
+            ResponseEntity<String> response = restTemplate.getForEntity(url, String.class);
+            log.info("Weather API Response Body: {}", response.getBody());
+
+            String responseBody = response.getBody();
+            if (responseBody == null || !responseBody.trim().startsWith("{")) {
+                log.error("Invalid API response: {}", responseBody);
+                throw new RuntimeException("올바른 JSON 응답이 아닙니다.");
+            }
+
+            // JSON 파싱
+            JSONArray items = new JSONObject(response.getBody())
+                    .getJSONObject("response")
+                    .getJSONObject("body")
+                    .getJSONObject("items")
+                    .getJSONArray("item");
+
+            // 4. 날씨 데이터 추출
+            String tmp = null, pty = null, sky = null, wsd = null,tmn=null,tmx=null;
+            int currentHour = now.getHour();
+
+// 가장 최근의 예보 시간을 찾기 위한 변수들
+            int closestHour = 0;
+            int minTimeDiff = 24; // 시간 차이 초기값
+
+            for (int i = 0; i < items.length(); i++) {
+                JSONObject item = items.getJSONObject(i);
+                String category = item.getString("category");
+                String value = item.getString("fcstValue");
+                String fcstTime = item.getString("fcstTime");
+
+                // 예보 시간을 정수로 변환 (예: "1500" -> 15)
+                int forecastHour = Integer.parseInt(fcstTime.substring(0, 2));
+
+                switch (category) {
+                    case WeatherConstants.TEMPERATURE:
+                        // 현재 시간과 가장 가까운 이전 예보 시간 찾기
+                        int timeDiff = (currentHour - forecastHour + 24) % 24;
+                        if (timeDiff < minTimeDiff && timeDiff >= 0) {
+                            minTimeDiff = timeDiff;
+                            closestHour = forecastHour;
+                            tmp = value;
+                        }
+                        break;
+                    case WeatherConstants.MAX_TEMP:
+                        tmx = value;
+                        break;
+                    case WeatherConstants.MIN_TEMP:
+                        tmn = value;
+                        break;
+                    case WeatherConstants.RAIN_TYPE:
+                        if (forecastHour == closestHour) pty = value;
+                        break;
+                    case WeatherConstants.SKY:
+                        if (forecastHour == closestHour) sky = value;
+                        break;
+                    case WeatherConstants.WIND_SPEED:
+                        if (forecastHour == closestHour) wsd = value;
+                        break;
+                }
+            }
+
+            // 5. 날씨 상태 결정
+            WeatherStatus status = WeatherStatus.fromWeatherData(pty, sky, Double.parseDouble(wsd));
+
+            // 6. 가장 가까운 D-day 찾기 (날씨가 흐린 경우)
+            Dday nearestDday = status == WeatherStatus.CLOUDY ? findNearestDday(user) : null;
+
+            // 7. 응답 생성
+            return WeatherResponseDto.from(
+                    status,
+                    pet.getDogCat(),
+                    user.getDistrict().getCity().getName() + " " + user.getDistrict().getName(),
+                    tmp,
+                    tmx,
+                    tmn,
+                    nearestDday
+            );
+
+        } catch (Exception e) {
+            log.error("날씨 정보 조회 중 오류 발생: {}", e.getMessage(), e);
+            throw new RuntimeException("날씨 정보를 조회할 수 없습니다: " + e.getMessage());
+        }
+    }
+
+    private Dday findNearestDday(User user) {
+        List<Dday> ddays = ddayRepository.findAllByUserOrderByDayAsc(user);
+        LocalDate today = LocalDate.now();
+
+        return ddays.stream()
+                .filter(dday -> {
+                    String title = dday.getTitle();
+                    // DDAY중 제목이 해당하는 것만 필터
+                    boolean isValidTitle = title.equals("사료 구매") ||
+                            title.equals("패드/모래 구매") ||
+                            title.equals("병원 방문일");
+                    // 오늘 이후의 날짜만 필터
+                    boolean isFutureDate = !dday.getDay().isBefore(today);
+
+                    return isValidTitle && isFutureDate;
+                })
+                .min(Comparator.comparing(Dday::getDay)) // 가장 가까운 날짜 선택
+                .orElse(null);
+    }
+}

--- a/src/main/java/DC_square/spring/service/WeatherService.java
+++ b/src/main/java/DC_square/spring/service/WeatherService.java
@@ -169,18 +169,18 @@ public class WeatherService {
             WeatherStatus status = WeatherStatus.fromWeatherData(pty, sky, Double.parseDouble(wsd));
 
             // 6. 가장 가까운 D-day 찾기 (날씨가 흐린 경우)
-            // 원래 코드
-           // Dday nearestDday = status == WeatherStatus.CLOUDY ? findNearestDday(user) : null;
+             //원래 코드
+            Dday nearestDday = status == WeatherStatus.CLOUDY ? findNearestDday(user) : null;
 
-            // 맑음일 때 테스트
-            Dday nearestDday = status == WeatherStatus.SUNNY ? findNearestDday(user) : null;
+//            // 맑음일 때 테스트
+//            Dday nearestDday = status == WeatherStatus.SUNNY ? findNearestDday(user) : null;
 
 
             // 7. 응답 생성
             return WeatherResponseDto.from(
                     status,
                     pet.getDogCat(),
-                    user.getDistrict().getCity().getName() + " " + user.getDistrict().getName(),
+                    user.getDistrict().getName(), //3 단계만
                     tmp,
                     tmx,
                     tmn,

--- a/src/main/java/DC_square/spring/service/WeatherService.java
+++ b/src/main/java/DC_square/spring/service/WeatherService.java
@@ -121,7 +121,7 @@ public class WeatherService {
                     .getJSONArray("item");
 
             // 4. 날씨 데이터 추출
-            String tmp = null, pty = null, sky = null, wsd = null,tmn=null,tmx=null;
+            String tmp = null, pty = null, sky = null, wsd = null,tmn=null,tmx=null,pop = null;
             int currentHour = now.getHour();
 
 // 가장 최근의 예보 시간을 찾기 위한 변수들
@@ -162,6 +162,9 @@ public class WeatherService {
                     case WeatherConstants.WIND_SPEED:
                         if (forecastHour == closestHour) wsd = value;
                         break;
+                    case WeatherConstants.RAIN_PROBABILITY:
+                        if (forecastHour == closestHour) pop = value;
+                        break;
                 }
             }
 
@@ -184,7 +187,8 @@ public class WeatherService {
                     tmp,
                     tmx,
                     tmn,
-                    nearestDday
+                    nearestDday,
+                    pop
             );
 
         } catch (Exception e) {

--- a/src/main/java/DC_square/spring/web/controller/RegionController.java
+++ b/src/main/java/DC_square/spring/web/controller/RegionController.java
@@ -19,11 +19,11 @@ public class RegionController {
 
     private final RegionService regionService;
 
-    @Operation(summary = "지역 생성 API")
-    @PostMapping
-    public ApiResponse<Long> createRegion(@RequestBody RegionRequestDTO request) {
-        regionService.creatRegion(request);
-        Long regionId = regionService.creatRegion(request);
-        return ApiResponse.onSuccess(regionId);
-    }
+//    @Operation(summary = "지역 생성 API")
+//    @PostMapping
+//    public ApiResponse<Long> createRegion(@RequestBody RegionRequestDTO request) {
+//        regionService.creatRegion(request);
+//        Long regionId = regionService.creatRegion(request);
+//        return ApiResponse.onSuccess(regionId);
+//    }
 }

--- a/src/main/java/DC_square/spring/web/controller/WeatherController.java
+++ b/src/main/java/DC_square/spring/web/controller/WeatherController.java
@@ -1,0 +1,43 @@
+package DC_square.spring.web.controller;
+
+import DC_square.spring.apiPayload.ApiResponse;
+import DC_square.spring.config.jwt.JwtTokenProvider;
+import DC_square.spring.domain.entity.User;
+import DC_square.spring.repository.community.UserRepository;
+import DC_square.spring.service.WeatherService;
+import DC_square.spring.web.dto.response.WeatherResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Weather", description = "날씨 관련 API")
+@RestController
+@RequestMapping("/api/weather")
+@RequiredArgsConstructor
+public class WeatherController {
+    private final WeatherService weatherService;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
+
+    @Operation(
+            summary = "현재 날씨 조회 API",
+            description = "사용자의 위치 기반 날씨 정보와 반려동물 맞춤 메시지를 조회합니다.",
+            security = @SecurityRequirement(name = "Authorization")
+    )
+    @GetMapping("/current")
+    public ApiResponse<WeatherResponseDto> getCurrentWeather(HttpServletRequest request) {
+        String token = jwtTokenProvider.resolveToken(request);
+        if (token == null || !jwtTokenProvider.validateToken(token)) {
+            throw new RuntimeException("유효하지 않은 토큰입니다.");
+        }
+
+        String userEmail = jwtTokenProvider.getUserEmail(token);
+        User user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+
+        return ApiResponse.onSuccess(weatherService.getCurrentWeather(user.getId()));
+    }
+}

--- a/src/main/java/DC_square/spring/web/dto/response/UserResponseDto.java
+++ b/src/main/java/DC_square/spring/web/dto/response/UserResponseDto.java
@@ -16,6 +16,9 @@ public class UserResponseDto {
     private String email;
     private String nickname;
     private String phoneNumber;
+    private String doName;  // Province name
+    private String si;  // City name
+    private String gu;    // District name
     private String regionId;
     private String profileImageUrl;
     private String token;
@@ -27,7 +30,9 @@ public class UserResponseDto {
                 .email(user.getEmail())
                 .nickname(user.getNickname())
                 .phoneNumber(user.getPhoneNumber())
-                .regionId(user.getRegionId())
+                .doName(user.getDistrict().getCity().getProvince().getName())
+                .si(user.getDistrict().getCity().getName())
+                .gu(user.getDistrict().getName())
                 .profileImageUrl(user.getProfileImageUrl())
                 .token(token)
                 .build();
@@ -40,8 +45,10 @@ public class UserResponseDto {
                 .email(user.getEmail())
                 .nickname(user.getNickname())
                 .phoneNumber(user.getPhoneNumber())
-                .regionId(user.getRegionId())
-                .profileImageUrl(user.getProfileImageUrl())
+                .doName(user.getDistrict().getCity().getProvince().getName())
+                .si(user.getDistrict().getCity().getName())
+                .gu(user.getDistrict().getName())
+//                .profileImageUrl(user.getProfileImageUrl())
                 .build();
 
     }

--- a/src/main/java/DC_square/spring/web/dto/response/WeatherResponseDto.java
+++ b/src/main/java/DC_square/spring/web/dto/response/WeatherResponseDto.java
@@ -19,6 +19,7 @@ public class WeatherResponseDto {
     private String maxTemp;         // 최고 기온
     private String minTemp;      // 최저 기온
     private String imageUrl;        // S3 이미지 URL
+    private String rainProbability;     // 강수 확률
 
     // D-day 관련 정보 (날씨가 흐릴 때만 사용)
     private String ddayTitle;       // D-day 제목
@@ -32,7 +33,8 @@ public class WeatherResponseDto {
             String currentTemp,
             String maxTemp,
             String minTemp,
-            Dday dday
+            Dday dday,
+            String pop
     ) {
         //소수점 제거
         String formattedMaxTemp = maxTemp != null ?
@@ -46,7 +48,9 @@ public class WeatherResponseDto {
                 .location(location)
                 .currentTemp(formattedCurrentTemp)
                 .maxTemp(formattedMaxTemp)
-                .minTemp(formattedMinTemp);
+                .minTemp(formattedMinTemp)
+                .rainProbability(pop != null ? pop + "%" : "0%");
+
 
         // D-day가 있고 날씨가 흐린 경우
         //기존 코드
@@ -67,6 +71,7 @@ public class WeatherResponseDto {
         setWeatherMessage(builder, status, petType);
         return builder.build();
     }
+
 
     private static void setWeatherMessage(WeatherResponseDtoBuilder builder, WeatherStatus status, DogCat petType) {
         boolean isDog = petType == DogCat.DOG;

--- a/src/main/java/DC_square/spring/web/dto/response/WeatherResponseDto.java
+++ b/src/main/java/DC_square/spring/web/dto/response/WeatherResponseDto.java
@@ -1,0 +1,107 @@
+package DC_square.spring.web.dto.response;
+
+import DC_square.spring.constant.WeatherConstants;
+import DC_square.spring.domain.entity.Dday;
+import DC_square.spring.domain.enums.DogCat;
+import DC_square.spring.domain.enums.WeatherStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.format.DateTimeFormatter;
+
+@Getter
+@Builder
+public class WeatherResponseDto {
+    private String mainMessage;     // 메인 메시지
+    private String subMessage;      // 보조 메시지
+    private String location;        // 지역 정보 (ex: 강남구 역삼동)
+    private String currentTemp;     // 현재 기온
+    private String maxTemp;         // 최고 기온
+    private String minTemp;         // 최저 기온
+    private String imageUrl;        // S3 이미지 URL
+
+    // D-day 관련 정보 (날씨가 흐릴 때만 사용)
+    private String ddayTitle;       // D-day 제목
+    private String ddayMessage;     // D-day 메시지 (D-3)
+    private String ddayDate;        // 날짜 (2024년 2월 10일)
+
+    public static WeatherResponseDto from(
+            WeatherStatus status,
+            DogCat petType,
+            String location,
+            String currentTemp,
+            String maxTemp,
+            String minTemp,
+            Dday dday
+    ) {
+        WeatherResponseDtoBuilder builder = WeatherResponseDto.builder()
+                .location(location)
+                .currentTemp(currentTemp + "°")
+                .maxTemp(maxTemp + "°")
+                .minTemp(minTemp + "°");
+
+        // D-day가 있고 날씨가 흐린 경우
+        if (dday != null && status == WeatherStatus.CLOUDY) {
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy년 M월 d일");
+            builder.ddayTitle(dday.getTitle())
+                    .ddayMessage("D-" + dday.getDaysLeft())
+                    .ddayDate(dday.getDay().format(formatter));
+
+            setDdayMessage(builder, petType, dday);
+            return builder.build();
+        }
+
+        // 날씨에 따른 메시지
+        setWeatherMessage(builder, status, petType);
+        return builder.build();
+    }
+
+    private static void setWeatherMessage(WeatherResponseDtoBuilder builder, WeatherStatus status, DogCat petType) {
+        boolean isDog = petType == DogCat.DOG;
+
+        switch (status) {
+            case SUNNY:
+                builder.mainMessage("오늘 날씨 맑음")
+                        .subMessage(isDog ? "산책하기 좋은 날" : "환기하기 좋은 날")
+                        .imageUrl(isDog ? WeatherConstants.DOG_SUN_IMAGE : WeatherConstants.CAT_SUN_IMAGE);
+                break;
+            case RAINY:
+                builder.mainMessage("비 오는 날")
+                        .subMessage(isDog ? "산책에 유의하세요" : "창문을 닫아주세요")
+                        .imageUrl(isDog ? WeatherConstants.DOG_RAIN_IMAGE : WeatherConstants.CAT_RAIN_IMAGE);
+                break;
+            case SNOWY:
+                builder.mainMessage("눈 오는 날")
+                        .subMessage(isDog ? "산책에 유의하세요" : "전기장판을 꺼내요")
+                        .imageUrl(isDog ? WeatherConstants.DOG_SNOW_IMAGE : WeatherConstants.CAT_SNOW_IMAGE);
+                break;
+            case WINDY:
+                builder.mainMessage("바람 부는날")
+                        .subMessage(isDog ? "산책에 유의하세요" : "털날림 주의")
+                        .imageUrl(isDog ? WeatherConstants.DOG_WIND_IMAGE : WeatherConstants.CAT_WIND_IMAGE);
+                break;
+        }
+    }
+
+    private static void setDdayMessage(WeatherResponseDtoBuilder builder, DogCat petType, Dday dday) {
+        boolean isDog = petType == DogCat.DOG;
+
+        switch (dday.getType()) {
+            case FOOD:
+                builder.mainMessage("사료 주문일이")
+                        .subMessage("다가오고있어요")
+                        .imageUrl(isDog ? WeatherConstants.DOG_BOX_IMAGE : WeatherConstants.CAT_BOX_IMAGE);
+                break;
+            case PAD:
+                builder.mainMessage(isDog ? "패드 구매일이" : "모래 구매일이")
+                        .subMessage("다가오고있어요")
+                        .imageUrl(isDog ? WeatherConstants.DOG_BOX_IMAGE : WeatherConstants.CAT_BOX_IMAGE);
+                break;
+            case HOSPITAL:
+                builder.mainMessage("병원 방문일이")
+                        .subMessage("다가오고있어요")
+                        .imageUrl(isDog ? WeatherConstants.DOG_HOSPITAL_IMAGE : WeatherConstants.CAT_HOSPITAL_IMAGE);
+                break;
+        }
+    }
+}

--- a/src/main/java/DC_square/spring/web/dto/response/WeatherResponseDto.java
+++ b/src/main/java/DC_square/spring/web/dto/response/WeatherResponseDto.java
@@ -41,7 +41,11 @@ public class WeatherResponseDto {
                 .minTemp(minTemp + "°");
 
         // D-day가 있고 날씨가 흐린 경우
-        if (dday != null && status == WeatherStatus.CLOUDY) {
+        //기존 코드
+      //  if (dday != null && status == WeatherStatus.CLOUDY) {
+
+        //테스트 (구름이 아닐 때도)
+        if (dday != null) {
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy년 M월 d일");
             builder.ddayTitle(dday.getTitle())
                     .ddayMessage("D-" + dday.getDaysLeft())

--- a/src/main/java/DC_square/spring/web/dto/response/WeatherResponseDto.java
+++ b/src/main/java/DC_square/spring/web/dto/response/WeatherResponseDto.java
@@ -17,7 +17,7 @@ public class WeatherResponseDto {
     private String location;        // 지역 정보 (ex: 강남구 역삼동)
     private String currentTemp;     // 현재 기온
     private String maxTemp;         // 최고 기온
-    private String minTemp;         // 최저 기온
+    private String minTemp;      // 최저 기온
     private String imageUrl;        // S3 이미지 URL
 
     // D-day 관련 정보 (날씨가 흐릴 때만 사용)
@@ -34,18 +34,26 @@ public class WeatherResponseDto {
             String minTemp,
             Dday dday
     ) {
+        //소수점 제거
+        String formattedMaxTemp = maxTemp != null ?
+                String.valueOf((int)Double.parseDouble(maxTemp)) + "°" : null;
+        String formattedMinTemp = minTemp != null ?
+                String.valueOf((int)Double.parseDouble(minTemp)) + "°" : null;
+        String formattedCurrentTemp = currentTemp != null ?
+                String.valueOf((int)Double.parseDouble(currentTemp)) + "°" : null;
+
         WeatherResponseDtoBuilder builder = WeatherResponseDto.builder()
                 .location(location)
-                .currentTemp(currentTemp + "°")
-                .maxTemp(maxTemp + "°")
-                .minTemp(minTemp + "°");
+                .currentTemp(formattedCurrentTemp)
+                .maxTemp(formattedMaxTemp)
+                .minTemp(formattedMinTemp);
 
         // D-day가 있고 날씨가 흐린 경우
         //기존 코드
-      //  if (dday != null && status == WeatherStatus.CLOUDY) {
+        if (dday != null && status == WeatherStatus.CLOUDY) {
 
         //테스트 (구름이 아닐 때도)
-        if (dday != null) {
+//        if (dday != null) {
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy년 M월 d일");
             builder.ddayTitle(dday.getTitle())
                     .ddayMessage("D-" + dday.getDaysLeft())

--- a/src/main/java/DC_square/spring/web/dto/response/user/UserInqueryResponseDto.java
+++ b/src/main/java/DC_square/spring/web/dto/response/user/UserInqueryResponseDto.java
@@ -19,6 +19,8 @@ public class UserInqueryResponseDto {
     private Boolean adAgree;
     private String firstPetBreed; // 첫 번째 반려동물 품종
     private String profileImageUrl;
+    private Integer gridX;
+    private Integer gridY;
 
 
     public static UserInqueryResponseDto fromUser(User user, String firstPetBreed) {
@@ -35,6 +37,8 @@ public class UserInqueryResponseDto {
                 .adAgree(user.getAdAgree())
                 .firstPetBreed(firstPetBreed)
                 .profileImageUrl(user.getProfileImageUrl())
+                .gridX(user.getDistrict().getCity().getGrid_X())
+                .gridY(user.getDistrict().getCity().getGrid_Y())
                 .build();
     }
 }

--- a/src/main/java/DC_square/spring/web/dto/response/user/UserInqueryResponseDto.java
+++ b/src/main/java/DC_square/spring/web/dto/response/user/UserInqueryResponseDto.java
@@ -2,6 +2,7 @@ package DC_square.spring.web.dto.response.user;
 
 import DC_square.spring.domain.entity.Region;
 import DC_square.spring.domain.entity.User;
+import DC_square.spring.domain.entity.region.District;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -19,15 +20,18 @@ public class UserInqueryResponseDto {
     private String firstPetBreed; // 첫 번째 반려동물 품종
     private String profileImageUrl;
 
-    public static UserInqueryResponseDto fromUser(User user, Region region, String firstPetBreed) {
+
+    public static UserInqueryResponseDto fromUser(User user, String firstPetBreed) {
+        District district = user.getDistrict();
+
         return UserInqueryResponseDto.builder()
                 .id(user.getId())
                 .email(user.getEmail())
                 .nickname(user.getNickname())
                 .phoneNumber(user.getPhoneNumber())
-                .doName(region.getDoName())
-                .si(region.getSi())
-                .gu(region.getGu())
+                .doName(district.getCity().getProvince().getName())
+                .si(district.getCity().getName())
+                .gu(district.getName())
                 .adAgree(user.getAdAgree())
                 .firstPetBreed(firstPetBreed)
                 .profileImageUrl(user.getProfileImageUrl())

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -77,3 +77,7 @@ google:
 # JWT
 jwt:
   secret: ${JWT_SECRET}
+
+  # 기상청 api
+  weather:
+    service-key: pGiiSWnFROiooklpxWToOg


### PR DESCRIPTION
📝 PR 요약(하나 이상의 PR 타입을 선택해주세요)
<!-- PR에 대한 간단한 설명을 작성해주세요 -->
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

💡 주요 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 작성해주세요 -->
기상청 단기예보 조회 api를 이용하여 회원 가입 때 등록한 지역정보를 이용해 홈화면 상단에 날씨 정보와 날씨에 맞는 이미지를 가져오고,

날씨가 흐릴 때에는 상단에 날씨에 대한 정보 말고 회원 가입 시 등록한 필수 D-day중 가장 다가오는 D-day에 대한 정보를 가져오게했습니다. 

🔍 관련 이슈
<!-- 관련된 이슈 번호를 작성해주세요 (예: #123) -->
56

🔄 브랜치 정보
병합 대상 브랜치: <!-- 예: main, develop -->dev
현재 작업 브랜치: <!-- 예: Minco/feat/user-authentication -->feat/minco/weather


🎯 테스트 방법
<!-- 리뷰어가 테스트할 수 있는 방법을 설명해주세요 -->
지역 테이블을 3개의 테이블로 구분하여, 회원가입 시 정확한 지역명(DB에 저장된)을 입력해주세요.

doName-si-gu => 이 3단계로 주소를 구분 함 
![image](https://github.com/user-attachments/assets/1e6c7dac-a296-4e82-a29d-eee5cb55f12c)

doName-> province테이블
si -> city테이블
gu -> district테이블
에 있는 값을 입력하면 됩니다.
---
테스트 완료화면

2025-02-09
오전 11시 날씨 
![image](https://github.com/user-attachments/assets/27dbfe8c-8384-43f6-bcad-c9ce84f9abdd)

서울 종로구 이화동(맑음)
![image](https://github.com/user-attachments/assets/bc1f7a9e-1c63-41ba-9dca-a5cc5fbcd783)

제주 연동 (비/눈)
![image](https://github.com/user-attachments/assets/6ff1e9a6-bc6c-4385-82bc-bfe2ce375a50)

목포 날씨 (흐림)
![image](https://github.com/user-attachments/assets/d37440e8-740b-43c5-82ef-eab3d4773216)


🚨 주의사항
<!-- 배포나 테스트 시 특별히 주의해야 할 사항을 작성해주세요 -->
build.gradle 과 yml파일 변경 ! 

지역 테이블을 3개의 테이블로 구분하여, 회원가입 시 정확한 지역명(DB에 저장된)을 입력해야 회원가입이 가능하며 저장된 위도경도 x,y를 기반으로 기상청 api를 호출 할 수 있습니다. 

